### PR TITLE
Fix build on musl

### DIFF
--- a/src/sys/unix.rs
+++ b/src/sys/unix.rs
@@ -7,7 +7,7 @@ pub fn reflink(from: &Path, to: &Path) -> io::Result<()> {
     use std::os::unix::io::AsRawFd;
 
     // TODO is this equal on all archs? Just tested on x86_64 and x86.
-    const IOCTL_FICLONE: u64 = 0x40049409;
+    macro_rules! IOCTL_FICLONE { () => (0x40049409) };
 
     let src = fs::File::open(&from)?;
 
@@ -18,7 +18,7 @@ pub fn reflink(from: &Path, to: &Path) -> io::Result<()> {
         .open(&to)?;
     let ret = unsafe {
         // http://man7.org/linux/man-pages/man2/ioctl_ficlonerange.2.html
-        libc::ioctl(dest.as_raw_fd(), IOCTL_FICLONE, src.as_raw_fd())
+        libc::ioctl(dest.as_raw_fd(), IOCTL_FICLONE!(), src.as_raw_fd())
     };
 
     if ret == -1 {


### PR DESCRIPTION
Use a macro to avoid specifying a type for our integer constant, allowing the compiler to pick the right option for musl and non-musl.

The tests pass, but I haven't convinced myself it is actually doing the right thing.

`strace` seems happy:

```
[pid 26431] ioctl(9, BTRFS_IOC_CLONE or FICLONE, 5) = 0
```

Fixes #4.